### PR TITLE
♻️ refactor: 공고 조회 시 지원 가능 여부 확인

### DIFF
--- a/src/main/java/com/sponus/sponusbe/domain/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/com/sponus/sponusbe/domain/announcement/dto/response/AnnouncementDetailResponse.java
@@ -20,9 +20,10 @@ public record AnnouncementDetailResponse(
 	String content,
 	List<AnnouncementImageResponse> announcementImages,
 	AnnouncementStatus status,
-	Long viewCount
+	Long viewCount,
+	boolean canApply // 공고 조회 시 지원 가능한지(처음 지원하는 것인지) 프론트에서 확인하기 위한 필드
 ) {
-	public static AnnouncementDetailResponse from(Announcement announcement) {
+	public static AnnouncementDetailResponse from(Announcement announcement, boolean canApply) {
 		List<AnnouncementImageResponse> announcementImages = announcement.getAnnouncementImages()
 			.stream()
 			.map(AnnouncementImageResponse::from)
@@ -40,6 +41,7 @@ public record AnnouncementDetailResponse(
 			.announcementImages(announcementImages)
 			.status(announcement.getStatus())
 			.viewCount(announcement.getViewCount())
+			.canApply(canApply)
 			.build();
 	}
 }

--- a/src/main/java/com/sponus/sponusbe/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/sponus/sponusbe/domain/announcement/service/AnnouncementService.java
@@ -66,7 +66,7 @@ public class AnnouncementService {
 		redisUtil.appendToRecentlyViewedAnnouncement(organization.getEmail() + "_recently_viewed_list",
 			String.valueOf(announcementId));
 
-		if (proposeRepository.findByProposingOrganizationId(organization.getId()).isPresent()) {
+		if (proposeRepository.findByProposingOrganizationIdAndAnnouncementId(organization.getId(), announcementId).isPresent()) {
 			return AnnouncementDetailResponse.from(announcement, false);
 		}
 

--- a/src/main/java/com/sponus/sponusbe/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/sponus/sponusbe/domain/announcement/service/AnnouncementService.java
@@ -23,6 +23,7 @@ import com.sponus.sponusbe.domain.announcement.exception.AnnouncementException;
 import com.sponus.sponusbe.domain.announcement.repository.AnnouncementRepository;
 import com.sponus.sponusbe.domain.announcement.repository.AnnouncementViewRepository;
 import com.sponus.sponusbe.domain.organization.entity.Organization;
+import com.sponus.sponusbe.domain.propose.repository.ProposeRepository;
 import com.sponus.sponusbe.domain.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class AnnouncementService {
 
 	private final AnnouncementRepository announcementRepository;
 	private final AnnouncementViewRepository announcementViewRepository;
+	private final ProposeRepository proposeRepository;
 	private final S3Service s3Service;
 	private final RedisUtil redisUtil;
 
@@ -64,7 +66,11 @@ public class AnnouncementService {
 		redisUtil.appendToRecentlyViewedAnnouncement(organization.getEmail() + "_recently_viewed_list",
 			String.valueOf(announcementId));
 
-		return AnnouncementDetailResponse.from(announcement);
+		if (proposeRepository.findByProposingOrganizationId(organization.getId()).isPresent()) {
+			return AnnouncementDetailResponse.from(announcement, false);
+		}
+
+		return AnnouncementDetailResponse.from(announcement, true);
 	}
 
 	public void deleteAnnouncement(Organization organization, Long announcementId) {

--- a/src/main/java/com/sponus/sponusbe/domain/propose/dto/response/ProposeDetailGetResponse.java
+++ b/src/main/java/com/sponus/sponusbe/domain/propose/dto/response/ProposeDetailGetResponse.java
@@ -28,7 +28,7 @@ public record ProposeDetailGetResponse(
 			.stream()
 			.map(ProposeAttachmentResponse::from)
 			.toList();
-		AnnouncementDetailResponse announcementDetails = AnnouncementDetailResponse.from(propose.getAnnouncement());
+		AnnouncementDetailResponse announcementDetails = AnnouncementDetailResponse.from(propose.getAnnouncement(), true);
 		return new ProposeDetailGetResponse(
 			propose.getId(),
 			propose.getTitle(),

--- a/src/main/java/com/sponus/sponusbe/domain/propose/dto/response/ProposeDetailGetResponse.java
+++ b/src/main/java/com/sponus/sponusbe/domain/propose/dto/response/ProposeDetailGetResponse.java
@@ -28,7 +28,7 @@ public record ProposeDetailGetResponse(
 			.stream()
 			.map(ProposeAttachmentResponse::from)
 			.toList();
-		AnnouncementDetailResponse announcementDetails = AnnouncementDetailResponse.from(propose.getAnnouncement(), true);
+		AnnouncementDetailResponse announcementDetails = AnnouncementDetailResponse.from(propose.getAnnouncement(), false);
 		return new ProposeDetailGetResponse(
 			propose.getId(),
 			propose.getTitle(),

--- a/src/main/java/com/sponus/sponusbe/domain/propose/repository/ProposeRepository.java
+++ b/src/main/java/com/sponus/sponusbe/domain/propose/repository/ProposeRepository.java
@@ -10,5 +10,5 @@ public interface ProposeRepository extends JpaRepository<Propose, Long> {
 
 	Optional<Propose> findByImpUid(String impUid);
 
-	Optional<Propose> findByProposingOrganizationId(Long proposingOrganizationId);
+	Optional<Propose> findByProposingOrganizationIdAndAnnouncementId(Long proposingOrganizationId, Long announcementId);
 }

--- a/src/main/java/com/sponus/sponusbe/domain/propose/repository/ProposeRepository.java
+++ b/src/main/java/com/sponus/sponusbe/domain/propose/repository/ProposeRepository.java
@@ -10,4 +10,5 @@ public interface ProposeRepository extends JpaRepository<Propose, Long> {
 
 	Optional<Propose> findByImpUid(String impUid);
 
+	Optional<Propose> findByProposingOrganizationId(Long proposingOrganizationId);
 }


### PR DESCRIPTION
# ☝️Issue Number

- resolves #219 

# 🔎 Key Changes
- 공고 조회 시, authOrganization을 사용하여 처음 제안하는 것인지 확인합니다.

# 💌 To Reviewers
- from 함수의 쓰임새가 한 곳이 아니라 프론트에서 쓰임새 파악하고 Response DTO를 더 구현해서 클린하게 하려 했지만.. 데모데이가 얼마 남지 않은 관계로 조금 의미 없는 변수가 사용되었습니다 참고해주세요! (ProposeDetailsGetResponse 31행)
- 우선 propose를 조회할 때는 기본적으로 제안을 한 상태일테니 false로 넣어두었습니다
