### PR TITLE
feat: 검색어 개별 삭제 기능 구현

### DIFF
--- a/api/src/main/java/com/sponus/sponusbe/domain/organization/controller/OrganizationController.java
+++ b/api/src/main/java/com/sponus/sponusbe/domain/organization/controller/OrganizationController.java
@@ -79,4 +79,13 @@ public class OrganizationController {
 	public ApiResponse<List<String>> getSearchHistory(@AuthOrganization Organization organization) {
 		return ApiResponse.onSuccess(organizationService.getSearchHistory(organization.getId()));
 	}
+
+	@DeleteMapping("/search/keywords")
+	public ApiResponse<Void> deleteSearchKeyword(
+		@AuthOrganization Organization organization,
+		@RequestParam("keyword") String keyword
+	) {
+		organizationService.deleteSearchKeyword(organization.getId(), keyword);
+		return ApiResponse.onSuccess(null);
+	}
 }

--- a/api/src/main/java/com/sponus/sponusbe/domain/organization/service/OrganizationService.java
+++ b/api/src/main/java/com/sponus/sponusbe/domain/organization/service/OrganizationService.java
@@ -89,7 +89,7 @@ public class OrganizationService {
 	public PageResponse<OrganizationSearchResponse> searchOrganizations(PageCondition pageCondition, String keyword,
 		Long organizationId) {
 
-		SearchHistory searchHistory = checkSearchHistory(organizationId);
+		SearchHistory searchHistory = findSearchHistory(organizationId);
 		searchHistory.getKeywords().add(keyword);
 		searchHistoryRepository.save(searchHistory);
 
@@ -107,7 +107,7 @@ public class OrganizationService {
 	}
 
 	public List<String> getSearchHistory(Long organizationId) {
-		Set<String> searchHistory = checkSearchHistory(organizationId).getKeywords();
+		Set<String> searchHistory = findSearchHistory(organizationId).getKeywords();
 
 		log.info("{} : ", searchHistory);
 
@@ -121,12 +121,21 @@ public class OrganizationService {
 		return searchHistoryList;
 	}
 
-	public SearchHistory checkSearchHistory(Long organizationId) {
+	public SearchHistory findSearchHistory(Long organizationId) {
 		return searchHistoryRepository.findById(organizationId).orElseGet(() -> {
 			SearchHistory newSearchHistory = SearchHistory.builder()
 				.organizationId(organizationId)
 				.build();
 			return searchHistoryRepository.save(newSearchHistory);
 		});
+	}
+
+	public void deleteSearchKeyword(Long organizationId, String keyword) {
+
+		// TODO 검색어 에러 처리
+		SearchHistory searchHistory = searchHistoryRepository.findById(organizationId)
+			.orElseThrow(() -> new OrganizationException(OrganizationErrorCode.ORGANIZATION_ERROR));
+		
+		searchHistory.getKeywords().remove(keyword);
 	}
 }


### PR DESCRIPTION
# ☝️Issue Number

- resolves #312

# 🔎 Key Changes

- 검색어 개별 삭제 기능 구현

# 💌 To Reviewers

- 검색 기록이 없는 경우 400으로 처리하긴 했는데, 검색 기록 조회에서 검색어가 있어야 삭제 api가 가능할텐데... 이 부분 예외 그대로 400으로 던져도 될까요..?
